### PR TITLE
fix：修改进去图片选择完之后，点击完成，再次跳转图库，已选择的图片在图库中没有显示为已选中状态

### DIFF
--- a/harmony/syan_image_picker/src/main/ets/RNSyanImagePickerModule.ts
+++ b/harmony/syan_image_picker/src/main/ets/RNSyanImagePickerModule.ts
@@ -74,7 +74,19 @@ export class RNSyanImagePickerTurboModule extends TurboModule implements TM.RNSy
       default:
         break;
     }
+    if (!!this.selectList && this.selectList.length > 0) {
+      let selectURI=[]
+      for (let i = 0; i < this.selectList.length; i++) {
+        if(imageOrVideo && this.isImage(this.selectList[i].original_uri)){
+          selectURI.push(this.selectList[i].original_uri)
+        }
 
+        if(!imageOrVideo && this.isVideo(this.selectList[i].original_uri)){
+          selectURI.push(this.selectList[i].original_uri)
+        }
+      }
+      optionsPassedToOHSelector.preselectedUris = selectURI
+    }
     return optionsPassedToOHSelector;
   }
 
@@ -340,7 +352,7 @@ export class RNSyanImagePickerTurboModule extends TurboModule implements TM.RNSy
       /**
        * Store the result of each selection at the end of the select list array
        */
-      this.selectList.push(...newResults);
+      this.selectList = newResults
       imagePickerResponseDataToClient.selectedPhoto = this.selectList;
     } catch (err) {
       imagePickerResponseDataToClient.errorMessage = `${err}`;


### PR DESCRIPTION
# Summary

*  修改进去图片选择完之后，点击完成，再次跳转图库，已选择的图片在图库中没有显示为已选中状态
    Close : [#26](https://github.com/react-native-oh-library/react-native-syan-image-picker/issues/26)。

## Test Plan

测试步骤：点击"选择照片(Promise)带base64"，选择几张照片之后，再次点击"选择照片(Promise)带base64"按钮，已选择的图片在图片列表中一已选中状态

![image](https://github.com/user-attachments/assets/1db13115-93dc-4411-b5f9-e6710d9382ff)
![image](https://github.com/user-attachments/assets/0d449a0f-bdd6-49a0-9c1d-8bd28d170eec)


## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [ ] 更新了 JS/TS 代码