### PR TITLE
fix：修改isCrop接口不生效问题

### DIFF
--- a/harmony/syan_image_picker/src/main/ets/RNSyanImagePickerModule.ts
+++ b/harmony/syan_image_picker/src/main/ets/RNSyanImagePickerModule.ts
@@ -432,7 +432,7 @@ export class RNSyanImagePickerTurboModule extends TurboModule implements TM.RNSy
         if (imagePickerResponseDataToClient.errorMessage) {
           callback(imagePickerResponseDataToClient.errorMessage, null);
         } else {
-          if (!options.allowPickingMultipleVideo) {
+          if (!options.allowPickingMultipleVideo && options.isCrop) {
             let bundleName=this.ctx.uiAbilityContext.abilityInfo.bundleName;
             try {
               let want: Want = {


### PR DESCRIPTION
# Summary

*  修改isCrop接口不生效问题
    Close : [#32](https://github.com/react-native-oh-library/react-native-syan-image-picker/issues/32)。

## Test Plan

测试步骤：点击"关闭压缩"，选择几张照片之后，点击完成不进行裁剪，直接返回原文件URL

![image](https://github.com/user-attachments/assets/1db13115-93dc-4411-b5f9-e6710d9382ff)
![image](https://github.com/user-attachments/assets/0d449a0f-bdd6-49a0-9c1d-8bd28d170eec)


## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [ ] 更新了 JS/TS 代码